### PR TITLE
Raw value transformation in get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 With TypeConf it's easy to retrieve typed configuration values from different sources:
 
-```typescript
+```js
 import TypeConf = require('typeconf');
 
 const conf = new TypeConf()
@@ -27,3 +27,33 @@ TypeConf supports different storage backends for configuration values:
 * **withStore(store: object, name?: string)** JavaScript object
 * **withSupplier(supplier: (key: string) => any, name?: string)** Supplier function
 * **set(key: string, value: any)** Override a value
+
+## API documentation
+
+### get(name: string): any
+
+Get a raw value.
+
+### get&lt;T&gt;(name: string, transform: (x: any) => T): T
+
+Get a value that is transformed by the supplied function.
+
+### getString(name: string, fallback?: string): string | undefined
+
+Get an existing value as a string (using `JSON.stringify` if necessary) or return an optional fallback string. **Throws TypeError** if `fallback` is defined but not a string.
+
+### getNumber(name: string, fallback?: number): number | undefined
+
+Get an existing value as a number (using `parseFloat` if necessary) or return an optional fallback number. **Throws TypeError** if an existing value cannot be interpreted as a number or if `fallback` is defined but not a number.
+
+### getBoolean(name: string): boolean
+
+Get a value as a boolean. An existing value is always interpreted as `true` unless it is `false` or `"false"`. A non-existing value is always interpreted as `false`.
+
+### getObject(name: string, fallback?: object): object | undefined
+
+Get an existing value as an object (using `JSON.parse` if necessary) or return an optional fallback object. **Throws TypeError** if an existing value cannot be interpreted as an object or if `fallback` is defined but not an object.
+
+### getType&lt;T&gt;(name: string, Newable: Newable&lt;T&gt;, fallback?: T): T | undefined
+
+Get an existing value as an instance of type `T` (by passing the raw value as the only argument to the constructor) or return an optional fallback value of the same type. **Throws TypeError** if an error occurs during the instantiation of type `T` (constructors should validate the raw configuration value).

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TypeConf throw a TypeError for an illegal number 1`] = `"Not a number: NaN"`;
+exports[`TypeConf throw a TypeError for an illegal fallback number 1`] = `"Not a number: null"`;
+
+exports[`TypeConf throw a TypeError for an illegal fallback object 1`] = `"Not an object: 0"`;
+
+exports[`TypeConf throw a TypeError for an illegal fallback string 1`] = `"Not a string: null"`;
 
 exports[`TypeConf throw a TypeError for an illegal object 1`] = `"Not an object: value"`;
+
+exports[`TypeConf throw a TypeError for an non-number 1`] = `"Not a number: true"`;
+
+exports[`TypeConf throw a TypeError for an unparsable number 1`] = `"Not a number: value"`;
 
 exports[`TypeConf throw a TypeError if a custom type cannot be instantiated 1`] = `"Cannot instantiate MyType from 42."`;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -53,8 +53,16 @@ describe('TypeConf', () => {
     expect(conf.getString('example', 'fallback')).toBe('fallback');
   });
 
+  test('return undefined without a fallback string', () => {
+    expect(conf.getString('example')).toBeUndefined();
+  });
+
   test('use a fallback number value', () => {
     expect(conf.getNumber('number', 1)).toBe(1);
+  });
+
+  test('return undefined without a fallback number', () => {
+    expect(conf.getNumber('number')).toBeUndefined();
   });
 
   test('override a string value', () => {
@@ -84,6 +92,16 @@ describe('TypeConf', () => {
     expect(conf.getObject('testObject')).toEqual({
       foo: 'bar'
     });
+  });
+
+  test('get a fallback object', () => {
+    expect(conf.getObject('test', { bar: 'foo' })).toEqual({
+      bar: 'foo'
+    });
+  });
+
+  test('return undefined without a fallback object', () => {
+    expect(conf.getObject('test')).toBeUndefined();
   });
 
   test('get an array', () => {
@@ -141,6 +159,11 @@ describe('TypeConf', () => {
     }
   }
 
+  test('get a converted type', () => {
+    conf.set('example', '42');
+    expect(conf.get('example', n => parseFloat(n))).toBe(42);
+  });
+
   test('get an instantiable type', () => {
     conf.set('example', { x: 'x', y: 42 });
     const value = conf.getType('example', MyType);
@@ -161,14 +184,31 @@ describe('TypeConf', () => {
     expect(() => conf.getType('example', MyType)).toThrowErrorMatchingSnapshot();
   });
 
-  test('throw a TypeError for an illegal number', () => {
+  test('throw a TypeError for an unparsable number', () => {
     conf.withFile(path.resolve(__dirname, 'conf.json'));
     expect(() => conf.getNumber('example')).toThrowErrorMatchingSnapshot();
+  });
+
+  test('throw a TypeError for an non-number', () => {
+    conf.withFile(path.resolve(__dirname, 'conf.json'));
+    expect(() => conf.getNumber('boolean')).toThrowErrorMatchingSnapshot();
+  });
+
+  test('throw a TypeError for an illegal fallback number', () => {
+    expect(() => conf.getNumber('number', null)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('throw a TypeError for an illegal fallback string', () => {
+    expect(() => conf.getString('example', null)).toThrowErrorMatchingSnapshot();
   });
 
   test('throw a TypeError for an illegal object', () => {
     conf.withFile(path.resolve(__dirname, 'conf.json'));
     expect(() => conf.getObject('example')).toThrowErrorMatchingSnapshot();
+  });
+
+  test('throw a TypeError for an illegal fallback object', () => {
+    expect(() => conf.getObject('example', 0 as any)).toThrowErrorMatchingSnapshot();
   });
 
   test('get values from a store', () => {


### PR DESCRIPTION
* transform raw values with a `transform` function argument in get()
* BREAKING: no more fallback argument in get()
