### PR TITLE
Don't merge other values behind env store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,8 @@ export default class TypeConf {
         if (result !== undefined) return result;
 
         const partial = getPartial(envName);
-        return merge({}, next(name), partial);
+        if (Object.keys(partial).length > 0) return merge({}, next(name), partial);
+        else return next(name);
       },
       has: (name, next) => {
         const envName = getEnvName(name);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -304,4 +304,16 @@ describe('TypeConf', () => {
     conf.withEnv('camel');
     expect(conf.get('example')).toEqual({ thisIsACamel: 'camel' });
   });
+
+  test('other values behind env storage are unaffected', () => {
+    process.env['COMBINATION_SOME'] = 'some';
+    conf
+      .withStore({
+        other: 'other'
+      })
+      .withEnv('COMBINATION');
+
+    expect(conf.getString('some')).toBe('some');
+    expect(conf.getString('other')).toBe('other');
+  });
 });


### PR DESCRIPTION
**FIX:** Do not merge other values in stores behind an ENV store into an object.

This bug would sometimes cause values like strings to be merged into an object.